### PR TITLE
Fix integration toggle error handling

### DIFF
--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -300,9 +300,20 @@ export default function IntegrationsPage() {
         body: JSON.stringify({ enabled: !integrations.find((i) => i.id === id)?.enabled }),
       })
 
-      if (!response.ok) throw new Error("Failed to toggle integration")
-    } catch (error) {
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        console.error("Toggle integration failed:", errorData)
+        alert(`Failed to toggle integration: ${errorData?.error || "Unknown error"}`)
+        throw new Error(
+          `Failed to toggle integration (Status ${response.status}): ${errorData?.error || "Unknown error"}`,
+        )
+      }
+
+      const result = await response.json()
+      console.log("Integration toggled:", result)
+    } catch (error: any) {
       console.error("Error toggling integration:", error)
+      alert(`Failed to toggle integration: ${error?.message || "Unknown error"}`)
     }
   }
 


### PR DESCRIPTION
## Summary
- improve error handling when toggling integrations to surface server errors
- support bulk integration queries via `id` or `ids` query params

## Testing
- `pnpm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687675b5a95c8331acf6dd1b5c35bf74