### PR TITLE
Add Supabase client and examples

### DIFF
--- a/app/api/integrations/[integrationId]/toggle/route.ts
+++ b/app/api/integrations/[integrationId]/toggle/route.ts
@@ -1,11 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 
+interface IntegrationRow {
+  id: string
+  status: boolean
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: { integrationId: string } },
 ) {
   try {
+    if (!params.integrationId) {
+      return NextResponse.json(
+        { success: false, error: 'Missing integration id' },
+        { status: 400 },
+      )
+    }
+
     const { enabled } = await request.json()
 
     if (typeof enabled !== 'boolean') {

--- a/app/api/integrations/[integrationId]/toggle/route.ts
+++ b/app/api/integrations/[integrationId]/toggle/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { integrationId: string } },
+) {
+  try {
+    const { enabled } = await request.json()
+
+    if (typeof enabled !== 'boolean') {
+      return NextResponse.json(
+        { success: false, error: 'Invalid payload' },
+        { status: 400 },
+      )
+    }
+
+    const { data, error } = await supabase
+      .from('integrations')
+      .update({ status: enabled })
+      .eq('id', params.integrationId)
+      .select('status')
+      .single()
+
+    if (error) {
+      console.error('Failed to update integration status', error)
+      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+
+    if (!data) {
+      return NextResponse.json({ success: false, error: 'Not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true, enabled: data.status })
+  } catch (err) {
+    console.error('Toggle integration error:', err)
+    return NextResponse.json({ success: false, error: 'Server error' }, { status: 500 })
+  }
+}

--- a/app/api/integrations/[integrationId]/toggle/route.ts
+++ b/app/api/integrations/[integrationId]/toggle/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 
-interface IntegrationRow {
-  id: string
-  status: boolean
+interface TogglePayload {
+  enabled: boolean
 }
 
 export async function POST(
@@ -11,16 +10,25 @@ export async function POST(
   { params }: { params: { integrationId: string } },
 ) {
   try {
-    if (!params.integrationId) {
+    const id = params.integrationId
+    if (!id) {
       return NextResponse.json(
         { success: false, error: 'Missing integration id' },
         { status: 400 },
       )
     }
 
-    const { enabled } = await request.json()
+    let body: TogglePayload | undefined
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'Invalid JSON body' },
+        { status: 400 },
+      )
+    }
 
-    if (typeof enabled !== 'boolean') {
+    if (!body || typeof body.enabled !== 'boolean') {
       return NextResponse.json(
         { success: false, error: 'Invalid payload' },
         { status: 400 },
@@ -29,23 +37,36 @@ export async function POST(
 
     const { data, error } = await supabase
       .from('integrations')
-      .update({ status: enabled })
-      .eq('id', params.integrationId)
-      .select('status')
+      .update({
+        enabled: body.enabled,
+        status: body.enabled,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select('enabled')
       .single()
 
     if (error) {
-      console.error('Failed to update integration status', error)
-      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+      console.error('Failed to update integration:', error)
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 500 },
+      )
     }
 
     if (!data) {
-      return NextResponse.json({ success: false, error: 'Not found' }, { status: 404 })
+      return NextResponse.json(
+        { success: false, error: 'Not found' },
+        { status: 404 },
+      )
     }
 
-    return NextResponse.json({ success: true, enabled: data.status })
+    return NextResponse.json({ success: true, enabled: data.enabled })
   } catch (err) {
     console.error('Toggle integration error:', err)
-    return NextResponse.json({ success: false, error: 'Server error' }, { status: 500 })
+    return NextResponse.json(
+      { success: false, error: 'Server error' },
+      { status: 500 },
+    )
   }
 }

--- a/app/api/my-table/route.ts
+++ b/app/api/my-table/route.ts
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
   try {
     const { name, email } = await request.json()
     const { data, error } = await supabase
-      .from<MyTableRow>("my_table")
+      .from("my_table")
       .insert({ name, email })
       .select()
       .single()
@@ -32,7 +32,7 @@ export async function PUT(request: NextRequest) {
     const { id, name, email } = await request.json()
 
     const { data, error } = await supabase
-      .from<MyTableRow>("my_table")
+      .from("my_table")
       .update({ name, email })
       .eq("id", id)
       .select()

--- a/app/api/my-table/route.ts
+++ b/app/api/my-table/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server"
+import { supabase } from "@/lib/supabase"
+
+interface MyTableRow {
+  id: string
+  name: string
+  email: string
+  created_at: string
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { name, email } = await request.json()
+    const { data, error } = await supabase
+      .from<MyTableRow>("my_table")
+      .insert({ name, email })
+      .select()
+      .single()
+
+    if (error) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, data })
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const { id, name, email } = await request.json()
+
+    const { data, error } = await supabase
+      .from<MyTableRow>("my_table")
+      .update({ name, email })
+      .eq("id", id)
+      .select()
+      .single()
+
+    if (error) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+
+    if (!data) {
+      return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true, data })
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 })
+  }
+}

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -305,19 +305,18 @@ export default function IntegrationsPage() {
         body: JSON.stringify({ enabled: nextEnabled }),
       })
 
+      const text = await response.text()
       let payload: any = null
       try {
-        payload = await response.json()
+        payload = text ? JSON.parse(text) : null
       } catch (err) {
         console.error("Failed to parse response JSON", err)
-        const text = await response.text().catch(() => "")
         if (text) payload = { error: text }
       }
 
       if (!response.ok || !payload || payload.success === false) {
         const message =
           payload?.error ||
-          payload?.message ||
           `Request failed with status ${response.status}`
         console.error("Toggle integration failed:", message)
         alert(`Failed to toggle integration: ${message}`)

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -305,16 +305,25 @@ export default function IntegrationsPage() {
         body: JSON.stringify({ enabled: nextEnabled }),
       })
 
-      let payload: any = null
+      let payload: any
+      let parseError: string | undefined
+
       try {
         payload = await response.json()
-      } catch {
-        const text = await response.text().catch(() => "")
-        if (text) payload = { error: text }
+      } catch (err: any) {
+        parseError = err?.message
+        try {
+          const text = await response.text()
+          if (text) payload = { error: text }
+        } catch {}
       }
 
-      if (!response.ok || !payload?.success) {
-        const message = payload?.error || `Request failed with status ${response.status}`
+      if (!response.ok || !payload || payload.success === false) {
+        const message =
+          payload?.error ||
+          payload?.message ||
+          parseError ||
+          `Request failed with status ${response.status}`
         console.error("Toggle integration failed:", message)
         alert(`Failed to toggle integration: ${message}`)
 

--- a/components/my-table-list.tsx
+++ b/components/my-table-list.tsx
@@ -17,7 +17,7 @@ export function MyTableList() {
   useEffect(() => {
     const fetchRows = async () => {
       const { data, error } = await supabase
-        .from<MyTableRow>("my_table")
+        .from("my_table")
         .select("*")
         .order("created_at", { ascending: false })
 

--- a/components/my-table-list.tsx
+++ b/components/my-table-list.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { supabase } from "@/lib/supabase"
+
+export interface MyTableRow {
+  id: string
+  name: string
+  email: string
+  created_at: string
+}
+
+export function MyTableList() {
+  const [rows, setRows] = useState<MyTableRow[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchRows = async () => {
+      const { data, error } = await supabase
+        .from<MyTableRow>("my_table")
+        .select("*")
+        .order("created_at", { ascending: false })
+
+      if (error) {
+        setError(error.message)
+      } else {
+        setRows(data ?? [])
+      }
+    }
+
+    fetchRows()
+  }, [])
+
+  if (error) return <div>Error: {error}</div>
+
+  return (
+    <ul>
+      {rows.map((row) => (
+        <li key={row.id}>
+          <strong>{row.name}</strong> ({row.email}) - {new Date(row.created_at).toLocaleString()}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,5 +2,5 @@ import { createClient } from '@supabase/supabase-js'
 
 export const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
 )

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3,6 +3,7 @@
 create table if not exists integrations (
   id uuid primary key default uuid_generate_v4(),
   name text not null,
+  enabled boolean default false,
   status boolean default false,
   created_at timestamptz default now(),
   updated_at timestamptz default now()

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,5 +1,13 @@
 -- Integration setup tables
 
+create table if not exists integrations (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  status boolean default false,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
 create table if not exists integration_credentials (
   id uuid primary key default uuid_generate_v4(),
   integration_id uuid references integrations(id),


### PR DESCRIPTION
## Summary
- configure Supabase client to use anon key
- provide MyTableList component example for fetching rows
- add example API route to insert and update `my_table`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6877966c6be48331837aaf1c684fdc7c